### PR TITLE
Remove abandoned headline

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -59,10 +59,6 @@ To be extra safe, you will be prompted before each step to confirm your intentio
 
 ![confirm run all commands](../static/img/confirm-run-all.png)
 
-### Split view of markdown and notebook
-
-It’s easy to get from notebook to markdown and vice versa.
-
 ### Run with Runme Deep Linking
 
 You can use Runme to on-board developers with a simple click on a button. It will trigger VS Code to clone a repository and open it for the user with a specific markdown file opened, e.g. an onboarding markdown file to have the user get started with the project:


### PR DESCRIPTION
In the original version it was documented as followed:

<img width="1057" alt="Screenshot 2023-06-08 at 16 27 06" src="https://github.com/stateful/docs.runme.dev/assets/731337/3e0ce0f6-ef41-4e68-84d0-384e47ac2069">

but was moved to a new chapter without cleaning up the old paragraph:
<img width="1166" alt="Screenshot 2023-06-08 at 16 28 15" src="https://github.com/stateful/docs.runme.dev/assets/731337/4b8a325f-4a60-4792-9bb7-b290b7d7ae7d">
