### PR TITLE
Mention CodeLense support in docs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -21,7 +21,7 @@ Easily switch between different views.
 
 ### Run a command block
 
-It's straightforward to run one-time command blocks directly from the raw markdown. And, what's even more convenient is that any changes made to the environment stay even when switching between markdown and notebook views.
+It's straightforward to run one-time command blocks directly from the raw markdown using VS Code's CodeLense feature. And, what's even more convenient is that any changes made to the environment stay even when switching between markdown and notebook views.
 
 ![run a command in vs code](../static/img/runme-editor-run.png)
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids",
-    "wdio": "wdio run ./wdio.conf.ts"
+    "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
     "@docusaurus/core": "^2.3.1",


### PR DESCRIPTION
When I was looking for CodeLens support in our docs I couldn't find much as we don't mention it anywhere. This little tweak makes sure it is being picked up by Algolia (presumably) and makes it easier to find.