### PR TITLE
Remove `$` signs in front of shell examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 ### Installation
 
 ```sh { name=npm-install }
-$ npm install
+npm install
 ```
 
 ### Local Development
 
 ```sh { name=npm-run-start background=true }
-$ rm -rf build/
-$ npm run start
+rm -rf build/
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -20,7 +20,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```sh { name=npm-run-build }
-$ npm run build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ If possible, always specify the language [according to the markdown standard](ht
 
 ```sh
     ```sh
-    $ echo "language identifier in fenced code block"
+    echo "language identifier in fenced code block"
     ```
 ```
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -17,7 +17,7 @@ Runme has a nice TUI that you can use simply like so:
 
 ```sh
 # short for "runme tui"
-$ runme
+runme
 ```
 
 ![Runme TUI Usage](../../static/img/runme-tui.gif)

--- a/docs/getting-started/web.md
+++ b/docs/getting-started/web.md
@@ -18,7 +18,7 @@ Runme can run as a self-contained web app. Since Runme's notebook UX is built on
 Just run following command:
 
 ```sh
-$ runme open
+runme open
 ```
 
 Runme will download and setup `code-server` for you and VS Code should be automatically opened in your default browser.

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,13 +18,13 @@ The Runme CLI is ideal for power users who want to run markdown documentation fr
 The easiest way on MacOS is to use Homebrew:
 
 ```sh
-$ brew update
+brew update
 ```
 
 Install runme
 
 ```sh
-$ brew install runme
+brew install runme
 ```
 
 ### On Windows
@@ -32,8 +32,8 @@ $ brew install runme
 On Windows, we distribute the binary through [Scoop.sh](https://scoop.sh/):
 
 ```sh
-$ scoop bucket add stateful https://github.com/stateful/scoop-bucket.git
-$ scoop install stateful/runme
+scoop bucket add stateful https://github.com/stateful/scoop-bucket.git
+scoop install stateful/runme
 ```
 
 #### Other Platforms
@@ -43,7 +43,7 @@ Alternatively, check out runme's [releases](https://github.com/stateful/runme/re
 If you have Go developer tools installed, you can install it with go install:
 
 ```sh
-$ go install github.com/stateful/runme@latest
+go install github.com/stateful/runme@latest
 ```
 
 If you don't have go developer tools installed and still want to use this method, [download and install go](https://go.dev/doc/install).
@@ -60,7 +60,7 @@ Runme has a nice TUI that you can use simply like so:
 
 ```sh
 # short for "runme tui"
-$ runme
+runme
 ```
 
 ![Runme TUI Usage](../static/img/runme-tui.gif)


### PR DESCRIPTION
We've received feedback from users about the `$` character being part of the copied text. I think we can remove it as it should be clear that the example is a shell environment.